### PR TITLE
Purge now sends deleted messages to the user.

### DIFF
--- a/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/mod/PurgeCommand.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/mod/PurgeCommand.java
@@ -8,7 +8,10 @@ import com.diamondfire.helpbot.bot.command.permissions.Permission;
 import com.diamondfire.helpbot.bot.command.reply.PresetBuilder;
 import com.diamondfire.helpbot.bot.command.reply.feature.informative.*;
 import com.diamondfire.helpbot.bot.events.CommandEvent;
+import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
+
+import java.time.format.DateTimeFormatter;
 
 public class PurgeCommand extends Command {
     
@@ -51,6 +54,27 @@ public class PurgeCommand extends Command {
         } else {
             TextChannel channel = event.getChannel();
             channel.getHistory().retrievePast(messagesToRemove).queue((messages) -> {
+                // Adds the messages to the messageBuilder object
+                MessageBuilder messageBuilder = new MessageBuilder();
+                messageBuilder.append("Here are the messages you purged;\n");
+                
+                for (Message m : messages) {
+                    messageBuilder
+                            .append("[")
+                            .append(m.getTimeCreated().format(DateTimeFormatter.RFC_1123_DATE_TIME))
+                            .append("] (").append(m.getAuthor().getAsMention()).append("): ")
+                            .append(m.getContentRaw())
+                            .append("\n");
+                }
+                
+                // Builds the MessageBuilder object and iterates through it.
+                // messageBuilder.buildAll() returns a queue of messages, split if the content exceeds 2000 characters.
+                for (Message message : messageBuilder.buildAll()) {
+                    event.getAuthor().openPrivateChannel().flatMap(userChannel ->
+                            userChannel.sendMessage(message)).queue();
+                }
+                
+                // Removes the messages.
                 channel.deleteMessages(messages).queue();
             });
         }

--- a/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/mod/PurgeCommand.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/mod/PurgeCommand.java
@@ -64,11 +64,12 @@ public class PurgeCommand extends Command {
                 // Iterates through the message history and appends the values to the MessageBuilder.
                 for (Message m : messages) {
                     messageBuilder
-                            .append("[")
-                            .append(m.getTimeCreated().format(DateTimeFormatter.RFC_1123_DATE_TIME))
-                            .append("] (").append(m.getAuthor().getAsMention()).append("): ")
-                            .append(m.getContentRaw())
-                            .append("\n");
+                            .append(
+                                    String.format("[%s] (%s): %s",
+                                            m.getTimeCreated().format(DateTimeFormatter.RFC_1123_DATE_TIME),
+                                            m.getAuthor().getAsMention(),
+                                            m.getContentRaw())
+                            );
                     if (!m.getAttachments().isEmpty()) {
                         for (Message.Attachment a : m.getAttachments()) {
                             attachments.put(a, m);
@@ -87,22 +88,15 @@ public class PurgeCommand extends Command {
                 for (Message.Attachment attachment : attachments.keySet()) {
                     event.getAuthor().openPrivateChannel().flatMap(userChannel ->
                     {
-                        try {
-                            MessageBuilder aBuilder = new MessageBuilder();
-                            Message mObject = attachments.get(attachment);
-                            aBuilder.append("[")
-                                    .append(mObject
-                                            .getTimeCreated().format(DateTimeFormatter.RFC_1123_DATE_TIME))
-                                    .append("] ")
-                                    .append(mObject
-                                            .getAuthor().getAsMention());
-                            return userChannel
-                                    .sendMessage(aBuilder.build())
-                                    .addFile(attachment.downloadToFile().get());
-                        } catch (InterruptedException | ExecutionException e) {
-                            e.printStackTrace();
-                        }
-                        return null;
+                        MessageBuilder aBuilder = new MessageBuilder();
+                        Message mObject = attachments.get(attachment);
+                        aBuilder.append(String.format(
+                                "[%s] %s sent this attachment: %s",
+                                        mObject.getTimeCreated().format(DateTimeFormatter.RFC_1123_DATE_TIME),
+                                        mObject.getAuthor().getAsMention(),
+                                        attachment.getProxyUrl()));
+                        return userChannel
+                                .sendMessage(aBuilder.build());
                     }).queue();
                 }
                 

--- a/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/mod/PurgeCommand.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/mod/PurgeCommand.java
@@ -61,12 +61,10 @@ public class PurgeCommand extends Command {
             channel.getHistory().retrievePast(messagesToRemove).queue((messages) -> {
                 // Adds the messages to the messageBuilder object
                 StringBuilder stringBuilder = new StringBuilder();
-                stringBuilder.append("Here are the messages you purged;\n");
                 
                 // Iterates through the message history and appends the values to the MessageBuilder.
                 for (Message m : messages) {
-                    stringBuilder
-                            .append(
+                    stringBuilder.insert(0,
                                     String.format("[%s] (%s): %s",
                                             m.getTimeCreated().format(DateTimeFormatter.RFC_1123_DATE_TIME),
                                             m.getAuthor().getName(),
@@ -74,17 +72,19 @@ public class PurgeCommand extends Command {
                             );
                     if (!m.getAttachments().isEmpty()) {
                         for (Message.Attachment a : m.getAttachments()) {
-                            stringBuilder.append(
+                            stringBuilder.insert(0,
                                     String.format(" [ATTACHMENT: %s ]\n",
                                             a.getProxyUrl())
                             );
                         }
                     } else {
-                        stringBuilder.append(
+                        stringBuilder.insert(0,
                                 "\n"
                         );
                     }
                 }
+    
+                stringBuilder.insert(0, "Here are the messages you purged;\n");
                 
                 try {
                     File file = ExternalFileUtil.generateFile("purge_log.txt");

--- a/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/mod/PurgeCommand.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/mod/PurgeCommand.java
@@ -12,6 +12,7 @@ import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
 
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 
 public class PurgeCommand extends Command {
     
@@ -58,6 +59,7 @@ public class PurgeCommand extends Command {
                 MessageBuilder messageBuilder = new MessageBuilder();
                 messageBuilder.append("Here are the messages you purged;\n");
                 
+                // Iterates through the message history and appends the values to the MessageBuilder.
                 for (Message m : messages) {
                     messageBuilder
                             .append("[")


### PR DESCRIPTION
Includes date/time sent, author as a mention, and the content of the messages. Does not send media attached. Most recent messages at the top of the output. Example output:
![image](https://user-images.githubusercontent.com/70416146/129478681-715d8e07-4ad0-4188-8024-26eb3b45b206.png)
Could always be changed slightly to send to a log channel in the server, although a new one would need to be created.