### PR TITLE
Help Improvements

### DIFF
--- a/src/main/java/com/diamondfire/helpbot/bot/HelpBotInstance.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/HelpBotInstance.java
@@ -53,6 +53,7 @@ public class HelpBotInstance {
                 // others
                 //new CowsayCommand(),
                 new MimicCommand(),
+                new SolvedCommand(),
                 //new FetchDataCommand(),
                 new InfoCommand(),
                 new EvalCommand(),
@@ -140,7 +141,7 @@ public class HelpBotInstance {
                 .setActivity(Activity.watching("for " + getConfig().getPrefix() + "help"))
                 .setGatewayEncoding(GatewayEncoding.ETF)
                 .disableCache(CacheFlag.ACTIVITY, CacheFlag.VOICE_STATE, CacheFlag.CLIENT_STATUS)
-                .addEventListeners(new MessageEvent(), new ReadyEvent(), new GuildJoinEvent(), new ButtonEvent(), new MessageEditEvent());
+                .addEventListeners(new MessageEvent(), new ReadyEvent(), new GuildJoinEvent(), new ButtonEvent(), new MessageEditEvent(), new PostAppliedTagsEvent(), new ChannelCreatedEvent(), new ChannelArchiveEvent());
         
         jda = builder.build();
         CommandHandler.getInstance().initialize();

--- a/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/util/SolvedCommand.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/util/SolvedCommand.java
@@ -74,7 +74,7 @@ public class SolvedCommand extends Command {
         }
         
         // Apply the solved tag, other behavior handled by PostAppliedTagsEvent.
-        var solvedTag = threadChannel.getParentChannel().asForumChannel().getAvailableTagById(HelpBotInstance.getConfig().getHelpChannelSolvedTag());
+        ForumTag solvedTag = threadChannel.getParentChannel().asForumChannel().getAvailableTagById(HelpBotInstance.getConfig().getHelpChannelSolvedTag());
         ArrayList<ForumTag> appliedTags = new ArrayList<>(threadChannel.getAppliedTags());
         if (!appliedTags.contains(solvedTag)) appliedTags.add(solvedTag);
         

--- a/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/util/SolvedCommand.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/command/impl/other/util/SolvedCommand.java
@@ -1,0 +1,87 @@
+package com.diamondfire.helpbot.bot.command.impl.other.util;
+
+import com.diamondfire.helpbot.bot.HelpBotInstance;
+import com.diamondfire.helpbot.bot.command.argument.ArgumentSet;
+import com.diamondfire.helpbot.bot.command.help.*;
+import com.diamondfire.helpbot.bot.command.impl.Command;
+import com.diamondfire.helpbot.bot.command.permissions.Permission;
+import com.diamondfire.helpbot.bot.command.reply.PresetBuilder;
+import com.diamondfire.helpbot.bot.command.reply.feature.informative.*;
+import com.diamondfire.helpbot.bot.events.CommandEvent;
+import net.dv8tion.jda.api.entities.channel.concrete.*;
+import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
+
+import java.util.*;
+
+
+public class SolvedCommand extends Command {
+    
+    @Override
+    public String getName() {
+        return "solved";
+    }
+    
+    @Override
+    public HelpContext getHelpContext() {
+        return new HelpContext()
+                .description("Marks the help post as solved.")
+                .category(CommandCategory.OTHER);
+    }
+    
+    @Override
+    public ArgumentSet compileArguments() {
+        return new ArgumentSet();
+    }
+    
+    @Override
+    public Permission getPermission() {
+        return Permission.USER;
+    }
+    
+    @Override
+    public void run(CommandEvent event) {
+        // Check if the command is used in the help forum.
+        if (event.getChannel().asThreadChannel().getParentChannel().getIdLong() != HelpBotInstance.getConfig().getHelpChannel()) {
+            event.reply(new PresetBuilder()
+                    .withPreset(
+                            new InformativeReply(InformativeReplyType.ERROR, "Command can only be used in <#" + HelpBotInstance.getConfig().getHelpChannel() + ">")
+                    ));
+            return;
+        }
+        
+        ThreadChannel threadChannel = event.getChannel().asThreadChannel();
+        
+        // Check if the command is used by the post owner.
+        if (event.getMember() == null | threadChannel.getOwnerIdLong() != event.getMember().getIdLong()) {
+            event.reply(new PresetBuilder()
+                    .withPreset(
+                            new InformativeReply(InformativeReplyType.ERROR, "Command can only be used by the post owner.")
+                    ));
+            return;
+        }
+        
+        // Check if the post is already locked.
+        if (threadChannel.isLocked()) {
+            event.reply(new PresetBuilder()
+                    .withPreset(
+                            new InformativeReply(InformativeReplyType.ERROR, "Post is already solved.")
+                    ));
+            return;
+        }
+        
+        // Apply the solved tag and lock the post.
+        var solvedTag = threadChannel.getParentChannel().asForumChannel().getAvailableTagById(HelpBotInstance.getConfig().getHelpChannelSolvedTag());
+        ArrayList<ForumTag> appliedTags = new ArrayList<>(threadChannel.getAppliedTags());
+        if (!appliedTags.contains(solvedTag)) appliedTags.add(solvedTag);
+        threadChannel.getManager().setAppliedTags(appliedTags).queue();
+        
+        threadChannel.getManager().setLocked(true).queue();
+        
+        event.reply(new PresetBuilder()
+                .withPreset(
+                        new InformativeReply(InformativeReplyType.SUCCESS, "Post marked as solved!")
+                ));
+        event.getChannel().asThreadChannel().getManager().setName("[ARCHIVED] " + event.getChannel().getName()).queue();
+    }
+    
+}

--- a/src/main/java/com/diamondfire/helpbot/bot/config/Config.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/config/Config.java
@@ -79,6 +79,14 @@ public class Config {
         return getPropertyLong("purge_evidence_channel");
     }
     
+    public long getHelpChannel() {
+        return getPropertyLong("help_channel");
+    }
+    
+    public long getHelpChannelSolvedTag() {
+        return getPropertyLong("help_channel_solved_tag");
+    }
+    
     public long getMutedRole() {
         return getPropertyLong("muted_role");
     }

--- a/src/main/java/com/diamondfire/helpbot/bot/events/ChannelArchiveEvent.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/events/ChannelArchiveEvent.java
@@ -1,0 +1,24 @@
+package com.diamondfire.helpbot.bot.events;
+
+import com.diamondfire.helpbot.bot.HelpBotInstance;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.events.channel.update.ChannelUpdateArchivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class ChannelArchiveEvent extends ListenerAdapter {
+    
+    @Override
+    public void onChannelUpdateArchived(ChannelUpdateArchivedEvent event) {
+        // Limit to help forum.
+        if (
+                event.getChannel().getType() != ChannelType.GUILD_PUBLIC_THREAD ||
+                        event.getChannel().asThreadChannel().getParentChannel().getIdLong() != HelpBotInstance.getConfig().getHelpChannel()
+        ) {
+            return;
+        }
+        
+        // When a post is archived, it should be locked.
+        event.getChannel().asThreadChannel().getManager().setLocked(true).queue();
+    }
+    
+}

--- a/src/main/java/com/diamondfire/helpbot/bot/events/ChannelCreatedEvent.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/events/ChannelCreatedEvent.java
@@ -1,0 +1,32 @@
+package com.diamondfire.helpbot.bot.events;
+
+import com.diamondfire.helpbot.bot.HelpBotInstance;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+import java.util.ArrayList;
+
+public class ChannelCreatedEvent extends ListenerAdapter {
+    
+    @Override
+    public void onChannelCreate(ChannelCreateEvent event) {
+        // Limit to help forum.
+        if (
+                event.getChannel().getType() != ChannelType.GUILD_PUBLIC_THREAD ||
+                        event.getChannel().asThreadChannel().getParentChannel().getIdLong() != HelpBotInstance.getConfig().getHelpChannel()
+        ) {
+            return;
+        }
+        
+        // Remove solved tag if post was created with it.
+        var solvedTag = event.getChannel().asThreadChannel().getParentChannel().asForumChannel().getAvailableTagById(HelpBotInstance.getConfig().getHelpChannelSolvedTag());
+        if (event.getChannel().asThreadChannel().getAppliedTags().contains(solvedTag)) {
+            var appliedTags = new ArrayList<>(event.getChannel().asThreadChannel().getAppliedTags());
+            appliedTags.remove(solvedTag);
+            event.getChannel().asThreadChannel().getManager().setAppliedTags(appliedTags).queue();
+        }
+        
+    }
+    
+}

--- a/src/main/java/com/diamondfire/helpbot/bot/events/ChannelCreatedEvent.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/events/ChannelCreatedEvent.java
@@ -2,6 +2,8 @@ package com.diamondfire.helpbot.bot.events;
 
 import com.diamondfire.helpbot.bot.HelpBotInstance;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
 import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
@@ -20,11 +22,13 @@ public class ChannelCreatedEvent extends ListenerAdapter {
         }
         
         // Remove solved tag if post was created with it.
-        var solvedTag = event.getChannel().asThreadChannel().getParentChannel().asForumChannel().getAvailableTagById(HelpBotInstance.getConfig().getHelpChannelSolvedTag());
-        if (event.getChannel().asThreadChannel().getAppliedTags().contains(solvedTag)) {
-            var appliedTags = new ArrayList<>(event.getChannel().asThreadChannel().getAppliedTags());
+        ThreadChannel threadChannel = event.getChannel().asThreadChannel();
+        
+        ForumTag solvedTag = threadChannel.getParentChannel().asForumChannel().getAvailableTagById(HelpBotInstance.getConfig().getHelpChannelSolvedTag());
+        if (threadChannel.getAppliedTags().contains(solvedTag)) {
+            ArrayList<ForumTag> appliedTags = new ArrayList<>(threadChannel.getAppliedTags());
             appliedTags.remove(solvedTag);
-            event.getChannel().asThreadChannel().getManager().setAppliedTags(appliedTags).queue();
+            threadChannel.getManager().setAppliedTags(appliedTags).queue();
         }
         
     }

--- a/src/main/java/com/diamondfire/helpbot/bot/events/PostAppliedTagsEvent.java
+++ b/src/main/java/com/diamondfire/helpbot/bot/events/PostAppliedTagsEvent.java
@@ -1,0 +1,40 @@
+package com.diamondfire.helpbot.bot.events;
+
+import com.diamondfire.helpbot.bot.HelpBotInstance;
+import com.diamondfire.helpbot.bot.command.reply.*;
+import com.diamondfire.helpbot.bot.command.reply.feature.informative.*;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.events.channel.update.ChannelUpdateAppliedTagsEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class PostAppliedTagsEvent extends ListenerAdapter {
+    
+    @Override
+    public void onChannelUpdateAppliedTags(ChannelUpdateAppliedTagsEvent event) {
+        // Limit to help forum.
+        if (event.getChannel().asThreadChannel().getParentChannel().getIdLong() != HelpBotInstance.getConfig().getHelpChannel()) {
+            return;
+        }
+        
+        var solvedTag = event.getChannel().asThreadChannel().getParentChannel().asForumChannel().getAvailableTagById(HelpBotInstance.getConfig().getHelpChannelSolvedTag());
+        
+        // If the solved tag is added and the post is not locked, lock the thread.
+        if (event.getAddedTags().contains(solvedTag) && !event.getChannel().asThreadChannel().isLocked()) {
+            event.getChannel().asThreadChannel().getManager().setLocked(true).queue();
+            ThreadChannel threadChannel = HelpBotInstance.getJda().getThreadChannelById(event.getChannel().getIdLong());
+            if (threadChannel != null) {
+                threadChannel.sendMessageEmbeds(
+                        new PresetBuilder()
+                                .withPreset(
+                                        new InformativeReply(InformativeReplyType.SUCCESS, "Post marked as solved")
+                                ).getEmbed().build()
+                ).queue();
+            }
+            event.getChannel().asThreadChannel().getManager().setName("[SOLVED] " + event.getChannel().getName()).queue();
+        } else if (event.getRemovedTags().contains(solvedTag) && event.getChannel().asThreadChannel().isLocked()) {
+            // If the solved tag is removed and the post is locked, put the old tags back.
+            event.getChannel().asThreadChannel().getManager().setAppliedTags(event.getOldTags()).queue();
+        }
+    }
+    
+}


### PR DESCRIPTION
# Solved
Adds two new fields to the `config.json`: (dfcord values)
```json
{
   "help_channel": 1024115123847172106,
   "help_channel_solved_tag": 1024142306661638164,
}
```

## ?solved
When the owner of a post in the `help_channel` runs ?solve, the `help_channel_solved_tag` is applied to it, the post is locked, and the name gets changed to `[SOLVED] <originalName>`.

## User-applied solved tag
When the `help_channel_solved_tag` is applied to any `help_channel`'s post:
**On channel creation** the tag is removed.
**On other cases** it is locked and has its name changed.

## Removed solved tag
When the `help_channel_solved_tag` is removed to a locked `help_channel`'s post the tag is put back.

# Lock closed posts
When a post in the `help_channel`is closed, it is also locked with no other changes.

# Screenshots
![image](https://github.com/user-attachments/assets/000ffe44-715f-4df1-9258-fdfbfa257af9)
![image](https://github.com/user-attachments/assets/de6ff2b2-7ba6-4a19-aafa-7fcb69e60f7d)
![image](https://github.com/user-attachments/assets/5cf543a3-2c09-46e5-bea1-05addc74ed27)

The changes were tested in edge cases such as other forums, threads outside of the help channel, moderator running ?solved on a solved post, post created with solved tag, and more.